### PR TITLE
fix: bump pnpm to v10 in publish workflow

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: pnpm/action-setup@v3
         name: Install pnpm
         with:
-            version: 8
+            version: 10
             run_install: false
       - name: Get pnpm store directory
         shell: bash
@@ -58,7 +58,7 @@ jobs:
       - uses: pnpm/action-setup@v3
         name: Install pnpm
         with:
-          version: 8
+          version: 10
           run_install: false
       - name: Get pnpm store directory
         shell: bash


### PR DESCRIPTION
## Summary
After #271 and #272 landed, the publish workflow now fails with:

\`\`\`
WARN  Ignoring not compatible lockfile at .../pnpm-lock.yaml
ERR_PNPM_NO_LOCKFILE  Cannot install with \"frozen-lockfile\" because pnpm-lock.yaml is absent
\`\`\`

The lockfile on main is now pnpm v10 format (it was regenerated in #271 with pnpm 10.33). The publish workflow still pins \`pnpm/action-setup@v3\` with \`version: 8\`, and pnpm v8 can't read v10 lockfiles — it silently ignores them, then \`--frozen-lockfile\` errors because there's no usable lockfile.

## Change
Bump both \`Install pnpm\` steps in the workflow from \`version: 8\` to \`version: 10\`.

Generated with [Claude Code](https://claude.com/claude-code)